### PR TITLE
Generate interfaces for public properties as well

### DIFF
--- a/Source/BoilerplateFree/AutoInterfaceGenerator.cs
+++ b/Source/BoilerplateFree/AutoInterfaceGenerator.cs
@@ -1,4 +1,7 @@
 // ReSharper disable SA1600
+
+using Microsoft.CodeAnalysis.CSharp;
+
 #pragma warning disable 1591
 namespace BoilerplateFree
 {
@@ -12,7 +15,7 @@ namespace BoilerplateFree
     using Microsoft.CodeAnalysis.Text;
 
     [Generator]
-    public class AutoInterfaceGenerator: ISourceGenerator
+    public class AutoInterfaceGenerator : ISourceGenerator
     {
         private AttributeClassSyntaxReceiver classSyntaxReceiver = null!;
         public List<string> Log { get; } = new();
@@ -22,7 +25,6 @@ namespace BoilerplateFree
             this.classSyntaxReceiver = new AttributeClassSyntaxReceiver(this.Log, "AutoGenerateInterface");
 
             context.RegisterForSyntaxNotifications(() => this.classSyntaxReceiver);
-
         }
 
         public void Execute(GeneratorExecutionContext context)
@@ -36,8 +38,10 @@ namespace BoilerplateFree
                 this.Log.Add(e.StackTrace);
             }
 
-            context.AddSource("Logs", SourceText.From($@"/*{ Environment.NewLine + string.Join(Environment.NewLine, this.Log) + Environment.NewLine}*/", Encoding.UTF8));
-
+            context.AddSource("Logs",
+                SourceText.From(
+                    $@"/*{Environment.NewLine + string.Join(Environment.NewLine, this.Log) + Environment.NewLine}*/",
+                    Encoding.UTF8));
         }
 
 
@@ -49,12 +53,14 @@ namespace BoilerplateFree
 
                 var classNamespace = compilationUnit.GetNamespace();
 
-                var usingsInsideNamespace = RoslynStringBuilders.BuildUsingStrings(compilationUnit.GetUsingsInsideNamespace());
-                var usingsOutsideNamespace = RoslynStringBuilders.BuildUsingStrings(compilationUnit.GetUsingsOutsideNamespace());
+                var usingsInsideNamespace =
+                    RoslynStringBuilders.BuildUsingStrings(compilationUnit.GetUsingsInsideNamespace());
+                var usingsOutsideNamespace =
+                    RoslynStringBuilders.BuildUsingStrings(compilationUnit.GetUsingsOutsideNamespace());
 
                 this.Log.Add($"Namespace: " + classNamespace);
 
-
+                var publicProperties = GetPublicProperties(declaringClass);
 
                 var classMethods = GetClassMethods(declaringClass);
 
@@ -68,6 +74,8 @@ namespace {classNamespace} {{
 
     {classMethods}
 
+    {publicProperties}
+
     }}
 }}
 ", Encoding.UTF8));
@@ -78,8 +86,12 @@ namespace {classNamespace} {{
         {
             string classMethods = "";
 
-            var nodes = declaringClass.DescendantNodes().OfType<MethodDeclarationSyntax>();
-            foreach (var methodDeclarationSyntax in nodes)
+            var nodes = declaringClass.ChildNodes().OfType<MethodDeclarationSyntax>();
+
+            var publicNodes = nodes.Where(property =>
+                property.Modifiers.Any(modifier => modifier.Kind() == SyntaxKind.PublicKeyword));
+
+            foreach (var methodDeclarationSyntax in publicNodes)
             {
                 this.Log.Add(methodDeclarationSyntax.Identifier.ToFullString());
 
@@ -92,25 +104,60 @@ namespace {classNamespace} {{
 
             return classMethods;
         }
-        
-        private string GetPublicClassGetters(ClassDeclarationSyntax declaringClass)
+
+        private string GetPublicProperties(ClassDeclarationSyntax declaringClass)
         {
             string properties = "";
 
-            var nodes = declaringClass.DescendantNodes().OfType<PropertyDeclarationSyntax>();
-            foreach (var propertyDeclarationSyntax in nodes)
-            {
-                this.Log.Add(propertyDeclarationSyntax.Identifier.ToFullString());
+            var nodes = declaringClass.ChildNodes().OfType<PropertyDeclarationSyntax>();
 
-                this.Log.Add(propertyDeclarationSyntax.ToFullString());
+            var publicNodes = nodes.Where(property =>
+                property.Modifiers.Any(modifier => modifier.Kind() == SyntaxKind.PublicKeyword));
+
+
+            foreach (var propertyDeclarationSyntax in publicNodes)
+            {
+                this.Log.Add("Property " + propertyDeclarationSyntax.Identifier.ToFullString());
+
+                this.Log.Add("Property " + propertyDeclarationSyntax.ToFullString());
+
+                var getter =
+                    propertyDeclarationSyntax.AccessorList?.Accessors.FirstOrDefault(x =>
+                        x.IsKind(SyntaxKind.GetAccessorDeclaration));
+
+                var hasExpressionBody = propertyDeclarationSyntax.ExpressionBody != null;
+
+                Log.Add("ExpressionBody: " + propertyDeclarationSyntax.ExpressionBody?.ToFullString() ??
+                        "no expression body");
+
+
+                var setter =
+                    propertyDeclarationSyntax.AccessorList?.Accessors.FirstOrDefault(x =>
+                        x.IsKind(SyntaxKind.SetAccessorDeclaration));
+
+                var getterSetterString = "";
+                if (getter != null || hasExpressionBody)
+                {
+                    getterSetterString += "get; ";
+                }
+                if (setter != null)
+                {
+                    getterSetterString += "set; ";
+                }
+
+                var fullString =
+                    $"public {propertyDeclarationSyntax.Type.ToFullString()} {propertyDeclarationSyntax.Identifier.ToFullString()} {{{getterSetterString}}}";
+
+
+                this.Log.Add("Property " + fullString);
 
                 // this is hacky as fuck
                 // Split on first ocurrence of ) which is probably the method end.
-                properties += propertyDeclarationSyntax.ToFullString().Split(')')[0] + "); \n";
+                properties += fullString + "\n";
             }
+
 
             return properties;
         }
     }
-
 }

--- a/Source/BoilerplateFree/AutoInterfaceGenerator.cs
+++ b/Source/BoilerplateFree/AutoInterfaceGenerator.cs
@@ -56,19 +56,7 @@ namespace BoilerplateFree
 
 
 
-                string classMethods = "";
-
-                var nodes = declaringClass.DescendantNodes().OfType<MethodDeclarationSyntax>();
-                foreach (var methodDeclarationSyntax in nodes)
-                {
-                    this.Log.Add(methodDeclarationSyntax.Identifier.ToFullString());
-
-                    this.Log.Add(methodDeclarationSyntax.ToFullString());
-
-                    // this is hacky as fuck
-                    // Split on first ocurrence of ) which is probably the method end.
-                    classMethods += methodDeclarationSyntax.ToFullString().Split(')')[0] + "); \n";
-                }
+                var classMethods = GetClassMethods(declaringClass);
 
                 var declaringClassName = declaringClass.GetClassName();
                 context.AddSource($"I{declaringClassName}.cs", SourceText.From($@"
@@ -84,6 +72,44 @@ namespace {classNamespace} {{
 }}
 ", Encoding.UTF8));
             }
+        }
+
+        private string GetClassMethods(ClassDeclarationSyntax declaringClass)
+        {
+            string classMethods = "";
+
+            var nodes = declaringClass.DescendantNodes().OfType<MethodDeclarationSyntax>();
+            foreach (var methodDeclarationSyntax in nodes)
+            {
+                this.Log.Add(methodDeclarationSyntax.Identifier.ToFullString());
+
+                this.Log.Add(methodDeclarationSyntax.ToFullString());
+
+                // this is hacky as fuck
+                // Split on first ocurrence of ) which is probably the method end.
+                classMethods += methodDeclarationSyntax.ToFullString().Split(')')[0] + "); \n";
+            }
+
+            return classMethods;
+        }
+        
+        private string GetPublicClassGetters(ClassDeclarationSyntax declaringClass)
+        {
+            string properties = "";
+
+            var nodes = declaringClass.DescendantNodes().OfType<PropertyDeclarationSyntax>();
+            foreach (var propertyDeclarationSyntax in nodes)
+            {
+                this.Log.Add(propertyDeclarationSyntax.Identifier.ToFullString());
+
+                this.Log.Add(propertyDeclarationSyntax.ToFullString());
+
+                // this is hacky as fuck
+                // Split on first ocurrence of ) which is probably the method end.
+                properties += propertyDeclarationSyntax.ToFullString().Split(')')[0] + "); \n";
+            }
+
+            return properties;
         }
     }
 

--- a/Source/BoilerplateFree/RoslynExtensions.cs
+++ b/Source/BoilerplateFree/RoslynExtensions.cs
@@ -1,3 +1,5 @@
+using Microsoft.CodeAnalysis.CSharp;
+
 #pragma warning disable 1591
 namespace BoilerplateFree
 {
@@ -92,11 +94,13 @@ namespace BoilerplateFree
                 .ToList();
         }
         
-        // public static IEnumerable<T> GetWithPublicKeyword<T>(IEnumerable<T> unfilteredTokens)
-        // where T: MemberDeclarationSyntax
-        // {
-        //     
-        // } 
+        public static IEnumerable<T> GetWithPublicKeyword<T>(this IEnumerable<T> unfilteredTokens)
+        where T: MemberDeclarationSyntax
+        {
+            var publicNodes = unfilteredTokens.Where(property =>
+                property.Modifiers.Any(modifier => modifier.Kind() == SyntaxKind.PublicKeyword));
+            return publicNodes;
+        } 
             
     }
 }

--- a/Source/BoilerplateFree/RoslynExtensions.cs
+++ b/Source/BoilerplateFree/RoslynExtensions.cs
@@ -91,5 +91,12 @@ namespace BoilerplateFree
                 .Select(n => n.Name.ToString())
                 .ToList();
         }
+        
+        // public static IEnumerable<T> GetWithPublicKeyword<T>(IEnumerable<T> unfilteredTokens)
+        // where T: MemberDeclarationSyntax
+        // {
+        //     
+        // } 
+            
     }
 }

--- a/Tests/BoilerplateFree.Test/AutoGenerateInterfaceTest.cs
+++ b/Tests/BoilerplateFree.Test/AutoGenerateInterfaceTest.cs
@@ -1,44 +1,32 @@
-namespace BoilerplateFree.Test
-{
-    using System;
-    using Subpackage;
-    using Xunit;
-
-    public class AutoGenerateInterfaceTest
-    {
-        [Fact]
-        public void AutoGenerateInterface_ShouldGenerateInterfaceWithAllPublicMethods()
-        {
-            // Arrange
-            IGenerateAutoInterfaceClass testClass = new GenerateAutoInterfaceClass();
-            // Act
-            testClass.Foo();
-            testClass.Bar(param1: 3);
-        }
-
-        [Fact]
-        public void AutoGenerateInterface_ShouldGenerateInterfaceWithSubclasses_WhenUsingsAreInsideNamespace()
-        {
-            IClassWithUsingsToGenerate testClass = new ClassWithUsingsToGenerate(new Subclass());
-            testClass.SetSubClass(new Subclass());
-        }
-
-        [Fact]
-        public void AutoGenerateInterface_ShouldGenerateInterfaceWithSubclasses_WhenUsingsAreOutsideNamespace()
-        {
-            IClassWithUsingsToGenerateOutsideNamespace testClass = new ClassWithUsingsToGenerateOutsideNamespace(new Subclass());
-            testClass.SetSubClass(new Subclass());
-        }
-
-        [AutoGenerateInterface]
-        public class GenerateAutoInterfaceClass : IGenerateAutoInterfaceClass
-        {
-            public void Foo()
-            {
-                Console.WriteLine("Foo");
-            }
-
-            public int Bar(int param1) => 1 + param1;
-        }
-    }
-}
+// namespace BoilerplateFree.Test
+// {
+//     using Subpackage;
+//     using Xunit;
+//
+//     public partial class AutoGenerateInterfaceTest
+//     {
+//         [Fact]
+//         public void AutoGenerateInterface_ShouldGenerateInterfaceWithAllPublicMethods()
+//         {
+//             // Arrange
+//             IGenerateAutoInterfaceClass testClass = new GenerateAutoInterfaceClass();
+//             // Act
+//             testClass.Foo();
+//             testClass.Bar(param1: 3);
+//         }
+//
+//         [Fact]
+//         public void AutoGenerateInterface_ShouldGenerateInterfaceWithSubclasses_WhenUsingsAreInsideNamespace()
+//         {
+//             IClassWithUsingsToGenerate testClass = new ClassWithUsingsToGenerate(new Subclass());
+//             testClass.SetSubClass(new Subclass());
+//         }
+//
+//         [Fact]
+//         public void AutoGenerateInterface_ShouldGenerateInterfaceWithSubclasses_WhenUsingsAreOutsideNamespace()
+//         {
+//             IClassWithUsingsToGenerateOutsideNamespace testClass = new ClassWithUsingsToGenerateOutsideNamespace(new Subclass());
+//             testClass.SetSubClass(new Subclass());
+//         }
+//     }
+// }

--- a/Tests/BoilerplateFree.Test/AutoGenerateInterfaceTest.cs
+++ b/Tests/BoilerplateFree.Test/AutoGenerateInterfaceTest.cs
@@ -1,32 +1,36 @@
-// namespace BoilerplateFree.Test
-// {
-//     using Subpackage;
-//     using Xunit;
-//
-//     public partial class AutoGenerateInterfaceTest
-//     {
-//         [Fact]
-//         public void AutoGenerateInterface_ShouldGenerateInterfaceWithAllPublicMethods()
-//         {
-//             // Arrange
-//             IGenerateAutoInterfaceClass testClass = new GenerateAutoInterfaceClass();
-//             // Act
-//             testClass.Foo();
-//             testClass.Bar(param1: 3);
-//         }
-//
-//         [Fact]
-//         public void AutoGenerateInterface_ShouldGenerateInterfaceWithSubclasses_WhenUsingsAreInsideNamespace()
-//         {
-//             IClassWithUsingsToGenerate testClass = new ClassWithUsingsToGenerate(new Subclass());
-//             testClass.SetSubClass(new Subclass());
-//         }
-//
-//         [Fact]
-//         public void AutoGenerateInterface_ShouldGenerateInterfaceWithSubclasses_WhenUsingsAreOutsideNamespace()
-//         {
-//             IClassWithUsingsToGenerateOutsideNamespace testClass = new ClassWithUsingsToGenerateOutsideNamespace(new Subclass());
-//             testClass.SetSubClass(new Subclass());
-//         }
-//     }
-// }
+namespace BoilerplateFree.Test
+{
+    using Subpackage;
+    using Xunit;
+
+    public partial class AutoGenerateInterfaceTest
+    {
+        [Fact]
+        public void AutoGenerateInterface_ShouldGenerateInterfaceWithAllPublicMethods()
+        {
+            // Arrange
+            IGenerateAutoInterfaceClass testClass = new GenerateAutoInterfaceClass();
+            // Act
+            testClass.Foo();
+            testClass.Bar(param1: 3);
+
+            // can read and write auto properties
+            int read = testClass.MyNextPublicInt;
+            testClass.MyNextPublicInt = 3;
+        }
+
+        [Fact]
+        public void AutoGenerateInterface_ShouldGenerateInterfaceWithSubclasses_WhenUsingsAreInsideNamespace()
+        {
+            IClassWithUsingsToGenerate testClass = new ClassWithUsingsToGenerate(new Subclass());
+            testClass.SetSubClass(new Subclass());
+        }
+
+        [Fact]
+        public void AutoGenerateInterface_ShouldGenerateInterfaceWithSubclasses_WhenUsingsAreOutsideNamespace()
+        {
+            IClassWithUsingsToGenerateOutsideNamespace testClass = new ClassWithUsingsToGenerateOutsideNamespace(new Subclass());
+            testClass.SetSubClass(new Subclass());
+        }
+    }
+}

--- a/Tests/BoilerplateFree.Test/BoilerplateFree.Test.csproj
+++ b/Tests/BoilerplateFree.Test/BoilerplateFree.Test.csproj
@@ -10,9 +10,9 @@
   </ItemGroup>
 
 
-  <PropertyGroup>
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-    <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
-  </PropertyGroup>
+<!--  <PropertyGroup>-->
+<!--    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>-->
+<!--    <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>-->
+<!--  </PropertyGroup>-->
 
 </Project>

--- a/Tests/BoilerplateFree.Test/GenerateAutoInterfaceClass.cs
+++ b/Tests/BoilerplateFree.Test/GenerateAutoInterfaceClass.cs
@@ -2,8 +2,8 @@ using System;
 
 namespace BoilerplateFree.Test
 {
-        [AutoGenerateInterface]
-        public class GenerateAutoInterfaceClass
+    [AutoGenerateInterface]
+        public class GenerateAutoInterfaceClass : IGenerateAutoInterfaceClass
         {
             public void Foo()
             {
@@ -12,9 +12,10 @@ namespace BoilerplateFree.Test
 
             public int Bar(int param1) => 1 + param1;
             
-            public int SuperSecret(int param1) => 1 + param1;
-
-            public int MyInt => 3;
-            public int MyNextInt { get; set; }
+            private int SuperSecretMethod(int param1) => 1 + param1;
+            private int SuperSecretProperty { get; set; }
+            
+            public int MyPublicIntWithDefaultImplementation => 3;
+            public int MyNextPublicInt { get; set; }
         }
 }

--- a/Tests/BoilerplateFree.Test/GenerateAutoInterfaceClass.cs
+++ b/Tests/BoilerplateFree.Test/GenerateAutoInterfaceClass.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace BoilerplateFree.Test
+{
+        [AutoGenerateInterface]
+        public class GenerateAutoInterfaceClass
+        {
+            public void Foo()
+            {
+                Console.WriteLine("Foo");
+            }
+
+            public int Bar(int param1) => 1 + param1;
+            
+            public int SuperSecret(int param1) => 1 + param1;
+
+            public int MyInt => 3;
+            public int MyNextInt { get; set; }
+        }
+}


### PR DESCRIPTION
Closes #10 

This PR does so that public properties with getters and setters also generate corresponding interface declarations.

