### PR TITLE
Ensure that interface members and constructor code isn't generated for static fields

### DIFF
--- a/Source/BoilerplateFree/AutoInterfaceGenerator.cs
+++ b/Source/BoilerplateFree/AutoInterfaceGenerator.cs
@@ -87,7 +87,8 @@ namespace {classNamespace} {{
             string classMethodsString = "";
 
             var publicNodes = declaringClass.ChildNodes().OfType<MethodDeclarationSyntax>()
-                .GetWithPublicKeyword();
+                .GetWithPublicKeyword()
+                .GetWithoutStaticKeyword();
 
             foreach (var methodDeclarationSyntax in publicNodes)
             {
@@ -109,7 +110,8 @@ namespace {classNamespace} {{
 
             var publicProperties = declaringClass.ChildNodes()
                 .OfType<PropertyDeclarationSyntax>()
-                .GetWithPublicKeyword();
+                .GetWithPublicKeyword()
+                .GetWithoutStaticKeyword();
 
 
             foreach (var propertyDeclarationSyntax in publicProperties)

--- a/Source/BoilerplateFree/ConstructorGenerator.cs
+++ b/Source/BoilerplateFree/ConstructorGenerator.cs
@@ -67,7 +67,9 @@ namespace BoilerplateFree
                 var usingsInsideNamespace = RoslynStringBuilders.BuildUsingStrings(compilationUnit.GetUsingsInsideNamespace());
                 var usingsOutsideNamespace = RoslynStringBuilders.BuildUsingStrings(compilationUnit.GetUsingsOutsideNamespace());
 
-                var fieldNodes = declaringClass.GetFields();
+                var fieldNodes = declaringClass.GetFields()
+                    .GetWithoutStaticKeyword();
+                
                 foreach (var field in fieldNodes)
                 {
                     this.Log.Add($"{field.ToFullString()} : type : {field.GetType()}");

--- a/Source/BoilerplateFree/RoslynExtensions.cs
+++ b/Source/BoilerplateFree/RoslynExtensions.cs
@@ -85,7 +85,7 @@ namespace BoilerplateFree
                 .Select(n => n.Name.ToString())
                 .ToList();
         }
-        
+
         public static List<string> GetUsingsOutsideNamespace(this CompilationUnitSyntax root)
         {
             return root.ChildNodes()
@@ -93,14 +93,21 @@ namespace BoilerplateFree
                 .Select(n => n.Name.ToString())
                 .ToList();
         }
-        
+
         public static IEnumerable<T> GetWithPublicKeyword<T>(this IEnumerable<T> unfilteredTokens)
-        where T: MemberDeclarationSyntax
+            where T : MemberDeclarationSyntax
         {
             var publicNodes = unfilteredTokens.Where(property =>
                 property.Modifiers.Any(modifier => modifier.Kind() == SyntaxKind.PublicKeyword));
             return publicNodes;
-        } 
-            
+        }
+
+        public static IEnumerable<T> GetWithoutStaticKeyword<T>(this IEnumerable<T> unfilteredTokens)
+            where T : MemberDeclarationSyntax
+        {
+            var nonStaticNodes = unfilteredTokens.Where(property => property.Modifiers.All(modifier =>
+                modifier.Kind() != SyntaxKind.StaticKeyword));
+            return nonStaticNodes;
+        }
     }
 }

--- a/Tests/BoilerplateFree.Test/AutoGenerateConstructorTests.cs
+++ b/Tests/BoilerplateFree.Test/AutoGenerateConstructorTests.cs
@@ -34,5 +34,7 @@ namespace BoilerplateFree.Test
         private int _firstVariable;
         private int _secondVariable;
         private int _thirdVariable;
+
+        private static int MyStaticField => 3;
     }
 }

--- a/Tests/BoilerplateFree.Test/GenerateAutoInterfaceClass.cs
+++ b/Tests/BoilerplateFree.Test/GenerateAutoInterfaceClass.cs
@@ -3,19 +3,32 @@ using System;
 namespace BoilerplateFree.Test
 {
     [AutoGenerateInterface]
-        public class GenerateAutoInterfaceClass : IGenerateAutoInterfaceClass
+    public class GenerateAutoInterfaceClass : IGenerateAutoInterfaceClass
+    {
+        public void Foo()
         {
-            public void Foo()
-            {
-                Console.WriteLine("Foo");
-            }
-
-            public int Bar(int param1) => 1 + param1;
-            
-            private int SuperSecretMethod(int param1) => 1 + param1;
-            private int SuperSecretProperty { get; set; }
-            
-            public int MyPublicIntWithDefaultImplementation => 3;
-            public int MyNextPublicInt { get; set; }
+            Console.WriteLine("Foo");
         }
+
+        public int Bar(int param1) => 1 + param1;
+
+        private int SuperSecretMethod(int param1) => 1 + param1;
+        private int SuperSecretProperty { get; set; }
+
+        public int MyPublicIntWithDefaultImplementation => 3;
+        public int MyNextPublicInt { get; set; }
+
+        public static int MyStaticMethod()
+        {
+            return 3;
+        }
+
+        public static int MyStaticProperty
+        {
+            get
+            {
+                return 3;
+            }
+        }
+    }
 }


### PR DESCRIPTION
Related to #11.

Ensure that interface methods and constructor fields aren't generated for static fields. 