### PR TITLE
Do not generate constructor parameters for already-initialized fields.

### DIFF
--- a/Source/BoilerplateFree/ConstructorGenerator.cs
+++ b/Source/BoilerplateFree/ConstructorGenerator.cs
@@ -52,7 +52,6 @@ namespace BoilerplateFree
                 var names = new List<string>();
                 var types = new List<string>();
 
-                // TODO there is a GetUsings in the extensions
 
                 var compilationUnit = declaringClass.GetCompilationUnit();
 
@@ -60,15 +59,12 @@ namespace BoilerplateFree
 
                 this.Log.Add($"Namespace: " + classNamespace);
 
-                // this.Log.Add(compilationUnit.ToFullString());
-                // this.Log.Add($"Usings count: {compilationUnit.GetUsings().Count}");
-                // this.Log.Add($"usings:" + string.Join(",", compilationUnit.GetUsings()));
-
                 var usingsInsideNamespace = RoslynStringBuilders.BuildUsingStrings(compilationUnit.GetUsingsInsideNamespace());
                 var usingsOutsideNamespace = RoslynStringBuilders.BuildUsingStrings(compilationUnit.GetUsingsOutsideNamespace());
 
                 var fieldNodes = declaringClass.GetFields()
-                    .GetWithoutStaticKeyword();
+                    .GetWithoutStaticKeyword()
+                    .GetUnInitialized();
                 
                 foreach (var field in fieldNodes)
                 {

--- a/Source/BoilerplateFree/RoslynExtensions.cs
+++ b/Source/BoilerplateFree/RoslynExtensions.cs
@@ -109,5 +109,11 @@ namespace BoilerplateFree
                 modifier.Kind() != SyntaxKind.StaticKeyword));
             return nonStaticNodes;
         }
+        
+        // Remove all fields that have an initializer already set (aka myVarName = "foo")
+        public static IEnumerable<FieldDeclarationSyntax> GetUnInitialized(this IEnumerable<FieldDeclarationSyntax> unfilteredTokens)
+        {
+            return unfilteredTokens.Where(token => token.Declaration.Variables.All((var) => var.Initializer == null));
+        }
     }
 }

--- a/Tests/BoilerplateFree.Test/AutoGenerateConstructorTestInitialized.cs
+++ b/Tests/BoilerplateFree.Test/AutoGenerateConstructorTestInitialized.cs
@@ -1,0 +1,28 @@
+﻿using Xunit;
+
+namespace BoilerplateFree.Test
+{
+    public class AutoGenerateConstructorTestConsts
+    {
+        [Fact]
+        public void AutoGenerateConstructor_ShouldOnlyGenerateConstructorFields_ForFieldsWithoutInitializers()
+        {
+            var myClass = new ClassWithInitializedFields("myStringIWanted");
+            Assert.Equal(123, myClass.myInt);
+            Assert.Equal("MyConst", ClassWithInitializedFields.MyConst);
+            Assert.Equal("myStringIWanted", myClass.myStringIWantFromConstructor);
+        }
+    }
+
+
+    
+    [AutoGenerateConstructor]
+    public partial class ClassWithInitializedFields
+    {
+        public const string MyConst = "MyConst";
+        public int myInt = 123;
+
+        public readonly string myStringIWantFromConstructor;
+
+    }
+}

--- a/todo.md
+++ b/todo.md
@@ -1,3 +1,5 @@
 
 # TODO
 - Somehow format the generated source files better, maybe by including dotnet-format?
+
+Use https://sharplab.io to debug syntax trees


### PR DESCRIPTION
Do not generate constructor stuff for fields that are already initialized, such as consts or fields with a default value