### PR TITLE
Added fix for empty constructors

### DIFF
--- a/Sample/SampleApplication/Services/repro-angehard/TestRepository.cs
+++ b/Sample/SampleApplication/Services/repro-angehard/TestRepository.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using BoilerplateFree;
+
+namespace BoilerPlateFreeTesting
+{
+    [AutoGenerateConstructor]
+    public partial class TestRepository
+    {
+        public string getTestData()
+        {
+            return "some-test-data";
+        }
+    }
+}

--- a/Sample/SampleApplication/Services/repro-angehard/TestService.cs
+++ b/Sample/SampleApplication/Services/repro-angehard/TestService.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using BoilerplateFree;
+using Microsoft.Extensions.Logging;
+
+namespace BoilerPlateFreeTesting
+{
+    [AutoGenerateConstructor]
+    public partial class TestService
+    {
+        private readonly TestRepository _testRepository;
+
+        public void runService()
+        {
+            var testData = _testRepository.getTestData();
+            Console.WriteLine($"giving out testdata: {testData}");
+        }
+    }
+}

--- a/Sample/SampleApplication/Startup.cs
+++ b/Sample/SampleApplication/Startup.cs
@@ -1,15 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+using BoilerPlateFreeTesting;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.HttpsPolicy;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 using SampleApplication.Services;
 
@@ -29,6 +23,10 @@ namespace SampleApplication
         {
             services.AddTransient<WeatherService>();
             services.AddControllers();
+            
+            services.AddTransient<TestRepository>();
+            services.AddTransient<TestService>();
+            
             services.AddSwaggerGen(c =>
             {
                 c.SwaggerDoc("v1", new OpenApiInfo {Title = "SampleApplication", Version = "v1"});
@@ -36,8 +34,10 @@ namespace SampleApplication
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, TestService testService)
         {
+            testService.runService();
+
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();

--- a/Source/BoilerplateFree/AutoInterfaceGenerator.cs
+++ b/Source/BoilerplateFree/AutoInterfaceGenerator.cs
@@ -37,6 +37,10 @@ namespace BoilerplateFree
             {
                 this.Log.Add(e.StackTrace);
                 this.Log.Add(e.ToString());
+                if (Environment.GetEnvironmentVariable("BOILERPLATEFREE_TEST") != "1")
+                {
+                    throw;
+                }
             }
             finally
             {

--- a/Source/BoilerplateFree/AutoInterfaceGenerator.cs
+++ b/Source/BoilerplateFree/AutoInterfaceGenerator.cs
@@ -36,12 +36,15 @@ namespace BoilerplateFree
             catch (Exception e)
             {
                 this.Log.Add(e.StackTrace);
+                this.Log.Add(e.ToString());
             }
-
-            context.AddSource("Logs",
-                SourceText.From(
-                    $@"/*{Environment.NewLine + string.Join(Environment.NewLine, this.Log) + Environment.NewLine}*/",
-                    Encoding.UTF8));
+            finally
+            {
+                context.AddSource("Logs",
+                    SourceText.From(
+                        $@"/*{Environment.NewLine + string.Join(Environment.NewLine, this.Log) + Environment.NewLine}*/",
+                        Encoding.UTF8));
+            }
         }
 
 

--- a/Source/BoilerplateFree/ConstructorGenerator.cs
+++ b/Source/BoilerplateFree/ConstructorGenerator.cs
@@ -38,6 +38,10 @@ namespace BoilerplateFree
             {
                 this.Log.Add(e.ToString());
                 this.Log.Add(e.StackTrace);
+                if (Environment.GetEnvironmentVariable("BOILERPLATEFREE_TEST") != "1")
+                {
+                    throw;
+                }
             }
             finally
             {

--- a/Tests/BoilerplateFree.Test/AutoGenerateConstructorWithEmptyTests.cs
+++ b/Tests/BoilerplateFree.Test/AutoGenerateConstructorWithEmptyTests.cs
@@ -1,0 +1,26 @@
+namespace BoilerplateFree.Test
+{
+    using BoilerplateFree;
+    using Subpackage;
+    using Xunit;
+
+    public class AutoGenerateConstructorTestsWithEmpty
+    {
+        [Fact]
+        public void AutoGenerateConstructor_ShouldBeAbleToGenerateConstructorForUnderscoredPrivateFields()
+        {
+            // We had an issue where accidentally adding [AutoGenerateConstructor] to a class without fields meant that it did not build properly
+            // because it tried to generate a constructor for an empty field-set.
+            var class1 = new ClassWithoutFields();
+            
+            Assert.Equal("3", class1.MyMethod());
+        }
+    }
+
+
+    [AutoGenerateConstructor]
+    public partial class ClassWithoutFields
+    {
+        public string MyMethod() => "3";
+    }
+}


### PR DESCRIPTION
Fixed #18 which is due to the fact that [AutoGenerateConstructor] is added to a class with no fields.

Also now rethrows the error for consumers, so they can actually see that something goes wrong in the build output.
